### PR TITLE
change reference for assets to work both on gh-pages & localhost

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,8 +7,8 @@
   <meta name="viewport" content="initial-scale=1.0, width=device-width">
   <!--<link rel="shortcut icon" href="/favicon.ico" />-->
   <link href='http://fonts.googleapis.com/css?family=Lora:400,400italic|Source+Code+Pro:300,400,700' rel='stylesheet' type='text/css'>
-  <link href="{{ site.baseurl }}/discotech/assets/bundle.css" rel="stylesheet">
-  <link href="{{ site.baseurl }}/discotech/assets/style.css" rel="stylesheet">
+  <link href="assets/bundle.css" rel="stylesheet">
+  <link href="assets/style.css" rel="stylesheet">
 </head>
 <body class="{{page.slug}}">
   <header>

--- a/_site/index.html
+++ b/_site/index.html
@@ -7,8 +7,8 @@
   <meta name="viewport" content="initial-scale=1.0, width=device-width">
   <!--<link rel="shortcut icon" href="/favicon.ico" />-->
   <link href='http://fonts.googleapis.com/css?family=Lora:400,400italic|Source+Code+Pro:300,400,700' rel='stylesheet' type='text/css'>
-  <link href="/assets/bundle.css" rel="stylesheet">
-  <link href="/assets/style.css" rel="stylesheet">
+  <link href="assets/bundle.css" rel="stylesheet">
+  <link href="assets/style.css" rel="stylesheet">
 </head>
 <body class="home">
   <header>


### PR DESCRIPTION
Saw your tweet about help wanted, but turns out it is decent enough and I don't think I can contribute too well. Here's a patch to enable running both on localhost & github pages (see [working copy](sudodoki.github.io/discotech)) w/o errors (localhost doesn't have `/discotech` in url).
Would suggest removing the `_site` part from github repo if you're planning on hosting site on github.
Kthxbye! :smile_cat: 